### PR TITLE
Upgrade openid-client to 5.x.x and fix API calls for new version

### DIFF
--- a/openid.js
+++ b/openid.js
@@ -90,8 +90,8 @@ module.exports = function (RED) {
 
     Issuer.discover(credentials.discovery_url).then(issuer => {
       const client = new issuer.Client(credentials)
-      client.authorizationCallback(credentials.redirect_uri, {code: req.query.code}).then((tokenSet) => {
-        const claims = tokenSet.claims
+      client.callback(credentials.redirect_uri, {code: req.query.code}).then((tokenSet) => {
+        const claims = tokenSet.claims()
         RED.nodes.addCredentials(node_id, Object.assign({}, credentials, {
           id_token: tokenSet.id_token,
           refresh_token: tokenSet.refresh_token,

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "node-red-contrib-openid",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Node-RED node to integrate OpenID Connect in flows",
   "dependencies": {
-    "openid-client": "^2.5.0"
+    "openid-client": "^5.1.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I had some issues with Twitch OIDC complaining about tokens issued in the future. Upgrading openid-client to 5.1.2 fixed this, and required only a couple of changes to the node that I could see, and those are mentioned as breaking changes in the openid-client changelog. We've been using it a few days already and nothing seems amiss.